### PR TITLE
Extended command line option '-u' so it negates construction state flags

### DIFF
--- a/csv2nq.py
+++ b/csv2nq.py
@@ -222,7 +222,7 @@ MIN_PERF = ""
 #
 # Assets and relationships.
 #
-def output_domain_assets(nqw, heading, entities):
+def output_domain_assets(nqw, unfiltered, heading, entities):
     # Output a heading for this section
     nqw.write_comment("")
     nqw.write_comment(heading)
@@ -262,7 +262,7 @@ def output_domain_assets(nqw, heading, entities):
             nqw.write_quad(uri, nqw.encode_ssm_uri("core#isAssertable"), isAssertable)
             nqw.write_quad(uri, nqw.encode_ssm_uri("core#isVisible"), isVisible)
             if(HAS_CONSTRUCTION_STATE in feature_list):
-                if(row[constructionState_index].lower() == "true"):
+                if(row[constructionState_index].lower() == "true" and not unfiltered):
                     nqw.write_quad(uri, nqw.encode_ssm_uri("core#isConstructionState"), isConstructionState)
 
             # Output a spacer at the end of this resource
@@ -298,7 +298,7 @@ def output_domain_assets(nqw, heading, entities):
     # Output a spacer at the end of this section
     nqw.write_comment("")
 
-def output_relationships(nqw, heading, entities):
+def output_relationships(nqw, unfiltered, heading, entities):
     # Output a heading for this section
     nqw.write_comment("")
     nqw.write_comment(heading)
@@ -342,7 +342,7 @@ def output_relationships(nqw, heading, entities):
             nqw.write_quad(uri, nqw.encode_ssm_uri("core#isVisible"), isVisible)
             nqw.write_quad(uri, nqw.encode_ssm_uri("core#hidden"), hidden)
             if(HAS_CONSTRUCTION_STATE in feature_list):
-                if(row[constructionState_index].lower() == "true"):
+                if(row[constructionState_index].lower() == "true" and not unfiltered):
                     nqw.write_quad(uri, nqw.encode_ssm_uri("core#isConstructionState"), isConstructionState)
 
             # Output a spacer at the end of this resource
@@ -2024,7 +2024,7 @@ parser = argparse.ArgumentParser(description="Convert from CSV files to NQ")
 parser.add_argument("-i", "--input", dest="input", required=True, metavar="directory", help="Directory containing CSV files for input")
 parser.add_argument("-o", "--output", dest="output", required=True, metavar="filename", help="Output NQ filename")
 parser.add_argument("-m", "--mapping", dest="mapping", metavar="filename", help="Output JSON icon-mapping filename")
-parser.add_argument("-u", "--unfiltered", help="Causes SSM GUI Misbehaviour and TWA visibility flags to be set to true.", action="store_true")
+parser.add_argument("-u", "--unfiltered", help="Causes SSM GUI Misbehaviour and TWA visibility flags to be set to true, construction state flags to false.", action="store_true")
 parser.add_argument("-e", "--expanded", help="Add population model support by expanding relevant structures", action="store_true")
 parser.add_argument("-v", "--version", help="Set the versionInfo string (defaults to timestamp) '-unfiltered' will be added to the version string if '-u' is used.")
 parser.add_argument("-n", "--name", help="Set the domainGraph string (defaults to what is found in DomainModel.csv). '-unexpanded' will be appended for population models unless '-e' is used.")
@@ -2032,7 +2032,7 @@ raw = parser.parse_args()
 args = vars(raw)
 
 if(raw.unfiltered):
-    print("Misbehaviour and TWA visibility flags set to TRUE")
+    print("Misbehaviour and TWA visibility flags set to TRUE, construction state flags to false")
 else:
     print("Misbehaviour and TWA visibility flags use domain model specifications")
 
@@ -2096,8 +2096,8 @@ with open(nq_filename, mode="w") as output:
     MIN_PERF = output_scale(nqw, False, "PerformanceImpactLevel.csv", "PerformanceImpactLevel", "Scale for Control Performance Overhead Levels")
     
     # Output assets and relationships, saving them for later
-    output_domain_assets(nqw, "Domain asset definitions", assets)
-    output_relationships(nqw, "Asset relationship definitions", relationships)
+    output_domain_assets(nqw, raw.unfiltered, "Domain asset definitions", assets)
+    output_relationships(nqw, raw.unfiltered, "Asset relationship definitions", relationships)
 
     # Output Roles, Controls, Misbehaviours and TWA, saving them for later
     output_roles(nqw, "Role definitions", roles)


### PR DESCRIPTION
in addition to MS/TWA visibility flags, addressing #4.

Useful for domain model development, when it is often necessary to inspect what happened during the construction pattern processing phase of validation. Deleting assets and links that are only needed during construction makes this very difficult, so having the option to retain them makes sense.