### PR TITLE
Issue #8: added a new option '-b' equivalent to '--label'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ Usage: `csv2nq.py [-h] -i directory -o filename [-m filename] [-u] [-e] [-v VERS
 Optional arguments are:
 
 ```
-  -h, --help            show this help message and exit
-  -m filename, --mapping filename
-                        Output JSON icon-mapping filename
-  -u, --unfiltered      Causes SSM GUI Misbehaviour and TWA visibility flags to be set to true.
-  -e, --expanded        Add population model support by expanding relevant structures
-  -v VERSION, --version VERSION
-                        Set the versionInfo string (defaults to timestamp) '-unfiltered' will be added to the version string if '-u' is used.
-  -n NAME, --name NAME  Set the domainGraph string (defaults to what is found in DomainModel.csv). '-unexpanded' will be appended for population models unless '-e'
-                        is used.
+  -h, --help                      show this help message and exit
+  -m filename, --mapping filename Output JSON icon-mapping filename
+  -l filename, --log filename     Logfile for diagnostic output
+  -u, --unfiltered                Causes SSM GUI Misbehaviour and TWA visibility flags to be set to true.
+  -e, --expanded                  Add population model support by expanding relevant structures
+  -n NAME, --name NAME            Set the domainGraph string (defaults to what is found in DomainModel.csv). '-unexpanded'
+                                  will be appended if the domain model supports populations but this is not enabled by
+                                  using '-e'.
+  -b LABEL, --label LABEL         Set the rdfs:label string (defaults to what is found in DomainModel.csv). '-UNEXPANDED'
+                                  will be appended if the domain model supports populations but this is not enabled by
+                                  using '-e'.
+  -v VERSION, --version VERSION   Set the versionInfo string (defaults to timestamp) '-unfiltered' will be added to
+                                  the version string if '-u' is used.
 ```

--- a/csv2nq.py
+++ b/csv2nq.py
@@ -119,13 +119,19 @@ def output_domain_model(nqw, unfiltered, heading):
             uri_frags[-1] = args["name"]
             domainGraph = "/".join(uri_frags)
 
+        label = row[label_index]
+        if args["label"]:
+            label = args["label"]
+        else:
+            label = row[label_index]
+
         if (not raw.expanded and HAS_POPULATION_MODEL in feature_list):
             domainGraph = "<{}-unexpanded>".format(domainGraph)
-            label = nqw.encode_string(row[label_index] + "-UNEXPANDED")
+            label = nqw.encode_string(label + "-UNEXPANDED")
             feature_list.remove(HAS_POPULATION_MODEL)
         else:
             domainGraph = "<{}>".format(domainGraph)
-            label = nqw.encode_string(row[label_index])
+            label = nqw.encode_string(label)
         comment = nqw.encode_string(row[comment_index])
 
         versionInfo = args["version"]
@@ -2177,6 +2183,7 @@ parser.add_argument("-u", "--unfiltered", help="Causes SSM GUI Misbehaviour and 
 parser.add_argument("-e", "--expanded", help="Add population model support by expanding relevant structures", action="store_true")
 parser.add_argument("-v", "--version", help="Set the versionInfo string (defaults to timestamp) '-unfiltered' will be added to the version string if '-u' is used.")
 parser.add_argument("-n", "--name", help="Set the domainGraph string (defaults to what is found in DomainModel.csv). '-unexpanded' will be appended for population models unless '-e' is used.")
+parser.add_argument("-b", "--label", help="Set the rdfs:label property (defaults to what is found in DomainModel.csv).")
 raw = parser.parse_args()
 args = vars(raw)
 

--- a/csv2nq.py
+++ b/csv2nq.py
@@ -122,8 +122,6 @@ def output_domain_model(nqw, unfiltered, heading):
         label = row[label_index]
         if args["label"]:
             label = args["label"]
-        else:
-            label = row[label_index]
 
         if (not raw.expanded and HAS_POPULATION_MODEL in feature_list):
             domainGraph = "<{}-unexpanded>".format(domainGraph)


### PR DESCRIPTION
This argument allows the rdfs:label property of the domain model to be specified, overriding the 'label' field in DomainModel.csv.

The string '-UNEXPANDED' is still appended if the domain model says it supports asset populations, but the csv2nq code is run without specifying the '-e' option so that the NQ file only supports singleton assets.

I found this necessary because during domain model development, I would specify the new version as 'domain-network-testing' so I could keep the current working version and the baseline version on one system-modeller. But I kept forgetting to change the label field in DomainModel.csv, so once deployed I couldn't tell which model was which as both the baseline and testing version were labelled as 'NETWORK'.

@kenmeacham : I asked you to do a review on this, but you may want to wait because further changes will be added on top and be the subject of further pull requests.