### PR TITLE
Issue #13 population support cmd line argument bug

### DIFF
--- a/csv2nq.py
+++ b/csv2nq.py
@@ -79,13 +79,14 @@ def output_domain_model(nqw, unfiltered, heading):
                 # Skip the first line which contains default values for csvformat
                 if DUMMY_URI in row: continue
 
-                # Check if the domain model specifies support for asset populations
-                if(row[uri_index] == HAS_POPULATION_MODEL):
-                    if(not raw.expanded):
-                        print("Domain model specifies population support, but this was suppressed by the csv2nq command line")
+                # Check if this row specifies whether the domain model supports for asset population triplet expansion
+                if(row[uri_index] == HAS_POPULATION_MODEL and not raw.expanded):
+                    print("Domain model specifies population support, but this was suppressed by the csv2nq command line")
+                    supported = False
+                else:
+                    supported = row[supported_index].lower() == "true"
 
                 # Write out the line if the feature is supported
-                supported = row[supported_index].lower() == "true"
                 if(supported):
                     feature_list.append(row[uri_index])
 


### PR DESCRIPTION
Fixes a bug whereby the cmd line argument controlling whether population triplets would be inserted was being ignored in some situations.

@kenmeacham : there is at least one more update coming on top of this, so you may want to skip this and look only at that. I just thought you might prefer to get each set of changes in a separate pull request. I think if you approve and merge them one by one then later pull requests become simpler as the already merged changes disappear. But I might be wrong...