### PR TITLE
10 support for modular domain models

### DIFF
--- a/csv2nq.py
+++ b/csv2nq.py
@@ -1778,32 +1778,33 @@ def output_threats(nqw, heading, misbehaviours, twas, roles, misbehaviour_sets, 
     nqw.write_comment("")
 
     # Output the CSG mitigates threat relationships
-    with open("ControlStrategyMitigates.csv", newline="") as csvfile:
-        # Create the CSV reader object
-        reader = csv.reader(csvfile)
+    if HAS_RISK_TYPE_FLAGS not in feature_list:
+        with open("ControlStrategyMitigates.csv", newline="") as csvfile:
+            # Create the CSV reader object
+            reader = csv.reader(csvfile)
 
-        # Check that the table is as expected: if fields are missing this will raise an exception
-        header = next(reader)
-        package_index = header.index("package")
-        uri_index = header.index("URI")
-        mitigates_index = header.index("mitigates")
+            # Check that the table is as expected: if fields are missing this will raise an exception
+            header = next(reader)
+            package_index = header.index("package")
+            uri_index = header.index("URI")
+            mitigates_index = header.index("mitigates")
 
-        for row in reader:
-            # Skip the first line which contains default values for csvformat
-            if DUMMY_URI in row: continue
+            for row in reader:
+                # Skip the first line which contains default values for csvformat
+                if DUMMY_URI in row: continue
 
-            # Skip this line if it is in a package that is not enabled
-            if not row[package_index] in package_list: continue
+                # Skip this line if it is in a package that is not enabled
+                if not row[package_index] in package_list: continue
 
-            # Extract the information we need from the next row
-            av_uri = nqw.encode_ssm_uri(row[uri_index])
-            av_mitigates = nqw.encode_ssm_uri(row[mitigates_index])
-            
-            # Output lines we need to the NQ file
-            nqw.write_quad(av_uri, nqw.encode_ssm_uri("core#mitigates"), av_mitigates)
+                # Extract the information we need from the next row
+                av_uri = nqw.encode_ssm_uri(row[uri_index])
+                av_mitigates = nqw.encode_ssm_uri(row[mitigates_index])
+                
+                # Output lines we need to the NQ file
+                nqw.write_quad(av_uri, nqw.encode_ssm_uri("core#mitigates"), av_mitigates)
 
-    # Output a spacer at the end of this section
-    nqw.write_comment("")
+        # Output a spacer at the end of this section
+        nqw.write_comment("")
     
     # Output the CSG triggers threat relationships
     with open("ControlStrategyTriggers.csv", newline="") as csvfile:

--- a/csv2nq.py
+++ b/csv2nq.py
@@ -181,8 +181,9 @@ def output_domain_model(nqw, unfiltered, heading):
         header = next(reader)
         uri_index = header.index("URI")
         label_index = header.index("Label")
-        enabled_index = header.index("Enabled")
         comment_index = header.index("Description")
+        if HAS_OPTIONAL_PACKAGES in feature_list:
+            enabled_index = header.index("Enabled")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
@@ -192,18 +193,26 @@ def output_domain_model(nqw, unfiltered, heading):
             uri = nqw.encode_ssm_uri(row[uri_index].replace("package#", "domain#Package-"))
             label = nqw.encode_string(row[label_index])
             comment = nqw.encode_string(row[comment_index])
-            enabled = nqw.encode_boolean(row[enabled_index])
+            if HAS_OPTIONAL_PACKAGES in feature_list:
+                # Find out whether this package is enabled
+                enabled = nqw.encode_boolean(row[enabled_index])
 
-            if(row[enabled_index].lower() == 'true'):
-                package_list.append(row[uri_index])
+                # Add it to the enabled package list only if it is enabled
+                if(row[enabled_index].lower() == 'true'):
+                    package_list.append(row[uri_index])
+                else:
+                    print("Package " + row[uri_index] + " is included but not enabled")
+
             else:
-                print("Package " + row[uri_index] + " is included but not enabled")
+                # No package is optional so add them all to the enabled package list
+                package_list.append(row[uri_index])
 
             # Ouput the row
             nqw.write_quad(uri, nqw.encode_rdfns_uri("22-rdf-syntax-ns#type"), nqw.encode_ssm_uri("core#ModelPackage"))
             nqw.write_quad(uri, nqw.encode_rdfs_uri("rdf-schema#label"), label)
             nqw.write_quad(uri, nqw.encode_rdfs_uri("rdf-schema#comment"), comment)
-            nqw.write_quad(uri, nqw.encode_ssm_uri("core#enabled"), enabled)
+            if HAS_OPTIONAL_PACKAGES in feature_list:
+                nqw.write_quad(uri, nqw.encode_ssm_uri("core#enabled"), enabled)
 
     #Echo the same list to the cmd line
     print("Domain model packages enabled: ")
@@ -307,6 +316,10 @@ def output_domain_assets(nqw, unfiltered, heading, entities):
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
+
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
             package = nqw.encode_ssm_uri(row[package_index].replace("package#", "domain#Package-"))
@@ -345,11 +358,15 @@ def output_domain_assets(nqw, unfiltered, heading, entities):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         subClassOf_index = header.index("subClassOf")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -387,6 +404,9 @@ def output_relationships(nqw, unfiltered, heading, entities):
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -428,11 +448,15 @@ def output_relationships(nqw, unfiltered, heading, entities):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         subPropertyOf_index = header.index("subPropertyOf")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -452,11 +476,15 @@ def output_relationships(nqw, unfiltered, heading, entities):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         domain_index = header.index("domain")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -476,11 +504,15 @@ def output_relationships(nqw, unfiltered, heading, entities):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         range_index = header.index("range")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -518,6 +550,9 @@ def output_roles(nqw, heading, entities):
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
 
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
+
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
             package = nqw.encode_ssm_uri(row[package_index].replace("package#", "domain#Package-"))
@@ -547,11 +582,15 @@ def output_roles(nqw, heading, entities):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         metaLocatedAt_index = header.index("metaLocatedAt")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -590,6 +629,9 @@ def output_cmr_entity(nqw, unfiltered, entityType, heading, infilename, locfilen
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             package = nqw.encode_ssm_uri(row[package_index].replace("package#", "domain#Package-"))
@@ -658,11 +700,15 @@ def output_cmr_entity(nqw, unfiltered, entityType, heading, infilename, locfilen
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         metaLocatedAt_index = header.index("metaLocatedAt")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             (min_uri, av_uri, max_uri) = nqw.encode_ssm_uri(add_minmax(row[uri_index]))
@@ -694,12 +740,16 @@ def output_twis(nqw, heading, twa_misbehaviour):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         affected_by_index = header.index("affectedBy")
         affects_index = header.index("affects")
     
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -761,12 +811,16 @@ def output_mis(nqw, heading):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         inhibited_index = header.index("inhibited")
         inhibited_by_index = header.index("inhibitedBy")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -810,6 +864,9 @@ def output_root_patterns(nqw, heading, roles, assets, relationships, nodes, link
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
 
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
+
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
             package = nqw.encode_ssm_uri(row[package_index].replace("package#", "domain#Package-"))
@@ -834,12 +891,16 @@ def output_root_patterns(nqw, heading, roles, assets, relationships, nodes, link
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         hasNode_index = header.index("hasNode")
         keyNode_index = header.index("keyNode")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -869,11 +930,15 @@ def output_root_patterns(nqw, heading, roles, assets, relationships, nodes, link
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         hasLink_index = header.index("hasLink")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -914,6 +979,9 @@ def output_matching_patterns(nqw, heading, roles, assets, relationships, nodes, 
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
 
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
+
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
             package = nqw.encode_ssm_uri(row[package_index].replace("package#", "domain#Package-"))
@@ -942,6 +1010,7 @@ def output_matching_patterns(nqw, heading, roles, assets, relationships, nodes, 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         has_node_index = header.index("hasNode")
         mandatory_node_index = header.index("mandatoryNode")
         prohibited_node_index = header.index("prohibitedNode")
@@ -950,6 +1019,9 @@ def output_matching_patterns(nqw, heading, roles, assets, relationships, nodes, 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -984,12 +1056,16 @@ def output_matching_patterns(nqw, heading, roles, assets, relationships, nodes, 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         hasLink_index = header.index("hasLink")
         prohibited_index = header.index("prohibited")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1017,11 +1093,15 @@ def output_matching_patterns(nqw, heading, roles, assets, relationships, nodes, 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         hasDistinctNodeGroup_index = header.index("hasDistinctNodeGroup")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1042,11 +1122,15 @@ def output_matching_patterns(nqw, heading, roles, assets, relationships, nodes, 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         hasNode_index = header.index("hasNode")
  
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1099,6 +1183,9 @@ def output_construction_patterns(nqw, heading, roles, assets, relationships, nod
                 # Skip the first line which contains default values for csvformat
                 if DUMMY_URI in row: continue
 
+                # Skip this line if it is in a package that is not enabled
+                if not row[package_index] in package_list: continue
+
                 # Extract the information we need from the next row
                 uri = nqw.encode_ssm_uri(row[uri_index])
                 package = nqw.encode_ssm_uri(row[package_index].replace("package#", "domain#Package-"))
@@ -1146,6 +1233,7 @@ def output_construction_patterns(nqw, heading, roles, assets, relationships, nod
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         inPattern_index = header.index("inPattern")
         hasNode_index = header.index("hasNode")
         hasSetting_index = header.index("hasSetting")
@@ -1156,6 +1244,9 @@ def output_construction_patterns(nqw, heading, roles, assets, relationships, nod
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             inPattern = nqw.encode_ssm_uri(row[inPattern_index])
@@ -1192,12 +1283,16 @@ def output_construction_patterns(nqw, heading, roles, assets, relationships, nod
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         includesNodeInURI_index = header.index("includesNodeInURI")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1216,12 +1311,16 @@ def output_construction_patterns(nqw, heading, roles, assets, relationships, nod
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         hasInferredLink_index = header.index("hasInferredLink")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1242,11 +1341,15 @@ def create_construction_sequence(cppredecessor, cpsequence):
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Initialise the predecessors dictionary entry (an empty list) and sequence number (initially zero)
             cppredecessor[row[uri_index]] = []
@@ -1259,6 +1362,7 @@ def create_construction_sequence(cppredecessor, cpsequence):
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         predecessor_index = header.index("hasPredecessor")
         fake_index = header.index("fake")
@@ -1266,6 +1370,9 @@ def create_construction_sequence(cppredecessor, cpsequence):
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract and save the information we need
             uri = row[uri_index]
@@ -1283,6 +1390,7 @@ def create_construction_sequence(cppredecessor, cpsequence):
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         successor_index = header.index("hasSuccessor")
         fake_index = header.index("fake")
@@ -1290,6 +1398,9 @@ def create_construction_sequence(cppredecessor, cpsequence):
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract and save the information we need
             uri = row[uri_index]
@@ -1352,6 +1463,8 @@ def output_threat_categories(nqw, heading):
         label_index = header.index("label")
         comment_index = header.index("comment")
 
+        # Note that threat categories are not in packages - they are treated like part of package#Core
+        
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
@@ -1386,6 +1499,7 @@ def output_compliance_sets(nqw, heading):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         label_index = header.index("label")
         comment_index = header.index("comment")
 
@@ -1393,6 +1507,9 @@ def output_compliance_sets(nqw, heading):
             for row in reader:
                 # Skip the first line which contains default values for csvformat
                 if DUMMY_URI in row: continue
+
+                # Skip this line if it is in a package that is not enabled
+                if not row[package_index] in package_list: continue
 
                 # Extract the information we need from the next row
                 uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1419,12 +1536,16 @@ def output_compliance_sets(nqw, heading):
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         requiresTreatmentOf_index = header.index("requiresTreatmentOf")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1466,6 +1587,9 @@ def output_threats(nqw, heading, misbehaviours, twas, roles, misbehaviour_sets, 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
 
@@ -1530,12 +1654,16 @@ def output_threats(nqw, heading, misbehaviours, twas, roles, misbehaviour_sets, 
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         hasEntryPoint_index = header.index("hasEntryPoint")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             av_uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1568,12 +1696,16 @@ def output_threats(nqw, heading, misbehaviours, twas, roles, misbehaviour_sets, 
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         has_sec_index = header.index("hasSecondaryEffectCondition")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             av_uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1596,12 +1728,16 @@ def output_threats(nqw, heading, misbehaviours, twas, roles, misbehaviour_sets, 
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         causes_misbehaviour_index = header.index("causesMisbehaviour")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             av_uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1624,12 +1760,16 @@ def output_threats(nqw, heading, misbehaviours, twas, roles, misbehaviour_sets, 
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         blocks_index = header.index("blocks")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             av_uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1648,12 +1788,16 @@ def output_threats(nqw, heading, misbehaviours, twas, roles, misbehaviour_sets, 
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         mitigates_index = header.index("mitigates")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             av_uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1672,12 +1816,16 @@ def output_threats(nqw, heading, misbehaviours, twas, roles, misbehaviour_sets, 
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         triggers_index = header.index("triggers")
 
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             av_uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1714,6 +1862,9 @@ def output_control_strategies(nqw, heading, controls, roles, control_sets):
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Get expansion prefix, which assumes the base URI is of the form domain#CSG-Body or domain#CSG-Body-[Tail] where Tail can include further dashes
             bits = row[uri_index][7:].split("-")
@@ -1760,6 +1911,7 @@ def output_control_strategies(nqw, heading, controls, roles, control_sets):
 
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         has_control_set_index = header.index("hasControlSet")
         optional_index = header.index("optional")
@@ -1767,6 +1919,9 @@ def output_control_strategies(nqw, heading, controls, roles, control_sets):
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             av_uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1811,6 +1966,7 @@ def output_casettings(nqw, heading):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         metaLocatedAt_index = header.index("metaLocatedAt")
         has_control_index = header.index("hasControl")
         is_assertable_index = header.index("isAssertable")
@@ -1820,6 +1976,9 @@ def output_casettings(nqw, heading):
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             control = row[has_control_index][7:]  # remove initial "domain#"
@@ -1882,6 +2041,7 @@ def output_twaa_default_levels(nqw, heading):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
+        package_index = header.index("package")
         metaLocatedAt_index = header.index("metaLocatedAt")
         twa_index = header.index("hasTrustworthinessAttribute")
         has_level_index = header.index("hasLevel")
@@ -1890,6 +2050,9 @@ def output_twaa_default_levels(nqw, heading):
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -1933,6 +2096,7 @@ def output_ma_default_levels(nqw, heading):
         
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
+        package_index = header.index("package")
         uri_index = header.index("URI")
         metaLocatedAt_index = header.index("metaLocatedAt")
         has_misbehaviour_index = header.index("hasMisbehaviour")
@@ -1941,6 +2105,9 @@ def output_ma_default_levels(nqw, heading):
         for row in reader:
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
+
+            # Skip this line if it is in a package that is not enabled
+            if not row[package_index] in package_list: continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])

--- a/csv2nq.py
+++ b/csv2nq.py
@@ -208,8 +208,7 @@ def output_domain_model(nqw, unfiltered, heading):
             nqw.write_quad(uri, nqw.encode_rdfns_uri("22-rdf-syntax-ns#type"), nqw.encode_ssm_uri("core#ModelPackage"))
             nqw.write_quad(uri, nqw.encode_rdfs_uri("rdf-schema#label"), label)
             nqw.write_quad(uri, nqw.encode_rdfs_uri("rdf-schema#comment"), comment)
-            if HAS_OPTIONAL_PACKAGES in feature_list:
-                nqw.write_quad(uri, nqw.encode_ssm_uri("core#enabled"), enabled)
+            nqw.write_quad(uri, nqw.encode_ssm_uri("core#enabled"), enabled)
 
     #Echo the same list to the cmd line
     print("Domain model packages enabled: ")

--- a/csv2nq.py
+++ b/csv2nq.py
@@ -1968,7 +1968,6 @@ def output_casettings(nqw, heading, controlTypes, assetTypes):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
-        package_index = header.index("package")
         metaLocatedAt_index = header.index("metaLocatedAt")
         has_control_index = header.index("hasControl")
         is_assertable_index = header.index("isAssertable")
@@ -1981,10 +1980,9 @@ def output_casettings(nqw, heading, controlTypes, assetTypes):
 
             # Extract the asset and control type, removing the initial "domain#"
             controlType = row[has_control_index][len("domain#"):]
-            assetType = row[metaLocatedAt_index][len("domain#"):]
 
             # Skip unless both are enabled
-            if (controlType not in controlTypes) or (assetType not in assetTypes): continue
+            if (row[has_control_index] not in controlTypes) or (row[metaLocatedAt_index] not in assetTypes): continue
 
             (min_uri, av_uri, max_uri) = nqw.encode_ssm_uri(add_minmax(row[uri_index], controlType))
             (min_control, av_control, max_control) = nqw.encode_ssm_uri(add_minmax(row[has_control_index]))
@@ -2045,7 +2043,6 @@ def output_twaa_default_levels(nqw, heading, twaTypes, assetTypes):
         # Check that the table is as expected: if fields are missing this will raise an exception
         header = next(reader)
         uri_index = header.index("URI")
-        package_index = header.index("package")
         metaLocatedAt_index = header.index("metaLocatedAt")
         twa_index = header.index("hasTrustworthinessAttribute")
         has_level_index = header.index("hasLevel")
@@ -2055,12 +2052,8 @@ def output_twaa_default_levels(nqw, heading, twaTypes, assetTypes):
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
 
-            # Extract the asset and TWA type, removing the initial "domain#"
-            twaType = row[twa_index][len("domain#"):]
-            assetType = row[metaLocatedAt_index][len("domain#"):]
-
             # Skip unless both are enabled
-            if (twaType not in twaTypes) or (assetType not in assetTypes): continue
+            if (row[twa_index] not in twaTypes) or (row[metaLocatedAt_index] not in assetTypes): continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])
@@ -2114,12 +2107,8 @@ def output_ma_default_levels(nqw, heading, misbehaviourTypes, assetTypes):
             # Skip the first line which contains default values for csvformat
             if DUMMY_URI in row: continue
 
-            # Extract the asset and TWA type, removing the initial "domain#"
-            misbehaviourType = row[has_misbehaviour_index][len("domain#"):]
-            assetType = row[metaLocatedAt_index][len("domain#"):]
-
             # Skip unless both are enabled
-            if (misbehaviourType not in misbehaviourTypes) or (assetType not in assetTypes): continue
+            if (row[has_misbehaviour_index] not in misbehaviourTypes) or (row[metaLocatedAt_index] not in assetTypes): continue
 
             # Extract the information we need from the next row
             uri = nqw.encode_ssm_uri(row[uri_index])


### PR DESCRIPTION
The changes here just cause all entities and relationships in a package to be omitted from the NQ file if (a) the domain model supports optional packages, and (b) the package is disabled in Packages.csv.

Currently there are no tests to ensure that there are no enabled packages that depend on a disabled package. I will add a check for that in the MS Access DB editor. We can move that check to CSV2NQ later, if appropriate.